### PR TITLE
Replace deprecated exec_program

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.15)
 project(pywinrt)
 
 add_executable(pywinrt)
@@ -6,7 +7,7 @@ target_include_directories(pywinrt PUBLIC ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE
 target_compile_definitions(pywinrt PUBLIC "PYWINRT_VERSION_STRING=\"${PYWINRT_BUILD_VERSION}\"")
 
 find_program(NUGET_EXE NAMES nuget)
-exec_program(${NUGET_EXE} ARGS install "Microsoft.Windows.WinMD" -Version "1.0.210629.2" -ExcludeVersion -OutputDirectory "${CMAKE_BINARY_DIR}/_packages")
+execute_process(COMMAND ${NUGET_EXE} install "Microsoft.Windows.WinMD" -Version 1.0.210629.2 -ExcludeVersion -OutputDirectory "${CMAKE_BINARY_DIR}/_packages")
 target_include_directories(pywinrt PRIVATE "${CMAKE_BINARY_DIR}/_packages/Microsoft.Windows.WinMD")
 
 GENERATE_STRING_LITERAL_FILES("${PROJECT_SOURCE_DIR}/strings/*" "strings" "pywinrt::strings" pywinrt)


### PR DESCRIPTION
Using exec_program also led to a `install: invalid arguments.` error for me.

The cmake_minimum_required is a guesstimate.