### PR TITLE
code_writers: make all buffer_format inline

### DIFF
--- a/src/code_writers.h
+++ b/src/code_writers.h
@@ -3169,7 +3169,7 @@ struct pinterface_python_type<%<%>>
     {
         w.write("template<>\n");
         w.write(
-            "constexpr const char* buffer_format<%> = \"%\";\n\n",
+            "inline constexpr const char* buffer_format<%> = \"%\";\n\n",
             type,
             // flags are UInt32, regular enums are Int32
             is_flags_enum(type) ? "I" : "i");
@@ -3277,7 +3277,7 @@ struct pinterface_python_type<%<%>>
 
         w.write("template<>\n");
         w.write(
-            "constexpr const char* buffer_format<%> = \"%\";\n\n",
+            "inline constexpr const char* buffer_format<%> = \"%\";\n\n",
             type,
             bind<write_struct_buffer_format_string>(type));
     }

--- a/src/strings/pybase.h
+++ b/src/strings/pybase.h
@@ -730,59 +730,59 @@ namespace py
     // PEP 3118 struct formats
 
     template<typename T, typename = void>
-    constexpr const char* buffer_format = 0;
+    inline constexpr const char* buffer_format = 0;
 
     template<>
-    constexpr const char* buffer_format<bool> = "?";
+    inline constexpr const char* buffer_format<bool> = "?";
 
     template<>
-    constexpr const char* buffer_format<int8_t> = "b";
+    inline constexpr const char* buffer_format<int8_t> = "b";
 
     template<>
-    constexpr const char* buffer_format<uint8_t> = "B";
+    inline constexpr const char* buffer_format<uint8_t> = "B";
 
     template<>
-    constexpr const char* buffer_format<int16_t> = "h";
+    inline constexpr const char* buffer_format<int16_t> = "h";
 
     template<>
-    constexpr const char* buffer_format<uint16_t> = "H";
+    inline constexpr const char* buffer_format<uint16_t> = "H";
 
     template<>
-    constexpr const char* buffer_format<int32_t> = "i";
+    inline constexpr const char* buffer_format<int32_t> = "i";
 
     template<>
-    constexpr const char* buffer_format<uint32_t> = "I";
+    inline constexpr const char* buffer_format<uint32_t> = "I";
 
     template<>
-    constexpr const char* buffer_format<int64_t> = "q";
+    inline constexpr const char* buffer_format<int64_t> = "q";
 
     template<>
-    constexpr const char* buffer_format<uint64_t> = "Q";
+    inline constexpr const char* buffer_format<uint64_t> = "Q";
 
     template<>
-    constexpr const char* buffer_format<float> = "f";
+    inline constexpr const char* buffer_format<float> = "f";
 
     template<>
-    constexpr const char* buffer_format<double> = "d";
+    inline constexpr const char* buffer_format<double> = "d";
 
     template<>
-    constexpr const char* buffer_format<char16_t> = "u";
+    inline constexpr const char* buffer_format<char16_t> = "u";
 
     template<>
-    constexpr const char* buffer_format<winrt::guid> = "T{I2H8B}";
+    inline constexpr const char* buffer_format<winrt::guid> = "T{I2H8B}";
 
     template<>
-    constexpr const char* buffer_format<winrt::hstring> = "P";
+    inline constexpr const char* buffer_format<winrt::hstring> = "P";
 
     template<>
-    constexpr const char* buffer_format<winrt::Windows::Foundation::IInspectable> = "P";
+    inline constexpr const char* buffer_format<winrt::Windows::Foundation::IInspectable> = "P";
 
     template<typename T>
-    constexpr const char* buffer_format<T, std::enable_if_t<is_class_category_v<T>>>
+    inline constexpr const char* buffer_format<T, std::enable_if_t<is_class_category_v<T>>>
         = "P";
 
     template<typename T>
-    constexpr const char* buffer_format<T, std::enable_if_t<is_interface_category_v<T>>>
+    inline constexpr const char* buffer_format<T, std::enable_if_t<is_interface_category_v<T>>>
         = "P";
 
     template<typename T>
@@ -791,10 +791,10 @@ namespace py
         = "P";
 
     template<>
-    constexpr const char* buffer_format<winrt::Windows::Foundation::DateTime> = "q";
+    inline constexpr const char* buffer_format<winrt::Windows::Foundation::DateTime> = "q";
 
     template<>
-    constexpr const char* buffer_format<winrt::Windows::Foundation::TimeSpan> = "q";
+    inline constexpr const char* buffer_format<winrt::Windows::Foundation::TimeSpan> = "q";
 
     template<typename T>
     struct buffer<T>


### PR DESCRIPTION
This avoids duplicate symbol definition when linking with clang.