### PR TITLE
projection: setup.py: fix build with MINGW64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@
 - Fixed building from source package with non-MSVC compiler ([#44]).
 - Fixed module load failing on systems without `msvcp140.dll` ([#43]).
 - Fixed installing from source in MSYS2 CLANG64 ([#47]).
+- Fixed installing from source in MSYS2 MINGW64 ([#46]).
 - Fixed crash when `winrt.system.Array()` called with no arguments.
 
 [#43]: https://github.com/pywinrt/pywinrt/issues/43
 [#44]: https://github.com/pywinrt/pywinrt/issues/44
+[#46]: https://github.com/pywinrt/pywinrt/issues/46
 [#47]: https://github.com/pywinrt/pywinrt/issues/47
 
 ## [v2.0.0-beta.2] - 2023-11-29

--- a/projection/interop/winrt-Windows.Foundation.Interop/setup.py
+++ b/projection/interop/winrt-Windows.Foundation.Interop/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/interop/winrt-Windows.Graphics.Capture.Interop/setup.py
+++ b/projection/interop/winrt-Windows.Graphics.Capture.Interop/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Graphics.DirectX/setup.py
+++ b/projection/winrt-Microsoft.Graphics.DirectX/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Graphics.Display/setup.py
+++ b/projection/winrt-Microsoft.Graphics.Display/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Composition.Core/setup.py
+++ b/projection/winrt-Microsoft.UI.Composition.Core/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Composition.Diagnostics/setup.py
+++ b/projection/winrt-Microsoft.UI.Composition.Diagnostics/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Composition.Effects/setup.py
+++ b/projection/winrt-Microsoft.UI.Composition.Effects/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Composition.Interactions/setup.py
+++ b/projection/winrt-Microsoft.UI.Composition.Interactions/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Composition.Scenes/setup.py
+++ b/projection/winrt-Microsoft.UI.Composition.Scenes/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Composition.SystemBackdrops/setup.py
+++ b/projection/winrt-Microsoft.UI.Composition.SystemBackdrops/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Composition/setup.py
+++ b/projection/winrt-Microsoft.UI.Composition/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Content/setup.py
+++ b/projection/winrt-Microsoft.UI.Content/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Dispatching/setup.py
+++ b/projection/winrt-Microsoft.UI.Dispatching/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Input.DragDrop/setup.py
+++ b/projection/winrt-Microsoft.UI.Input.DragDrop/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Input.Interop/setup.py
+++ b/projection/winrt-Microsoft.UI.Input.Interop/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Input/setup.py
+++ b/projection/winrt-Microsoft.UI.Input/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.System/setup.py
+++ b/projection/winrt-Microsoft.UI.System/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Text/setup.py
+++ b/projection/winrt-Microsoft.UI.Text/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Windowing/setup.py
+++ b/projection/winrt-Microsoft.UI.Windowing/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Automation.Peers/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Automation.Peers/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Automation.Provider/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Automation.Provider/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Automation.Text/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Automation.Text/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Automation/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Automation/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Controls.AnimatedVisuals/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Controls.AnimatedVisuals/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Controls.Primitives/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Controls.Primitives/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Controls/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Controls/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Data/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Data/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Documents/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Documents/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Hosting/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Hosting/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Input/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Input/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Interop/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Interop/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Markup/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Markup/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Media.Animation/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Media.Animation/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Media.Imaging/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Media.Imaging/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Media.Media3D/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Media.Media3D/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Media/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Media/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Navigation/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Navigation/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Printing/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Printing/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Resources/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Resources/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.Shapes/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.Shapes/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml.XamlTypeInfo/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml.XamlTypeInfo/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI.Xaml/setup.py
+++ b/projection/winrt-Microsoft.UI.Xaml/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.UI/setup.py
+++ b/projection/winrt-Microsoft.UI/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Web.WebView2.Core/setup.py
+++ b/projection/winrt-Microsoft.Web.WebView2.Core/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.AppLifecycle/setup.py
+++ b/projection/winrt-Microsoft.Windows.AppLifecycle/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.AppNotifications.Builder/setup.py
+++ b/projection/winrt-Microsoft.Windows.AppNotifications.Builder/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.AppNotifications/setup.py
+++ b/projection/winrt-Microsoft.Windows.AppNotifications/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.ApplicationModel.DynamicDependency/setup.py
+++ b/projection/winrt-Microsoft.Windows.ApplicationModel.DynamicDependency/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.ApplicationModel.Resources/setup.py
+++ b/projection/winrt-Microsoft.Windows.ApplicationModel.Resources/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.ApplicationModel.WindowsAppRuntime/setup.py
+++ b/projection/winrt-Microsoft.Windows.ApplicationModel.WindowsAppRuntime/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.Management.Deployment/setup.py
+++ b/projection/winrt-Microsoft.Windows.Management.Deployment/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.PushNotifications/setup.py
+++ b/projection/winrt-Microsoft.Windows.PushNotifications/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.Security.AccessControl/setup.py
+++ b/projection/winrt-Microsoft.Windows.Security.AccessControl/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.System.Power/setup.py
+++ b/projection/winrt-Microsoft.Windows.System.Power/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.System/setup.py
+++ b/projection/winrt-Microsoft.Windows.System/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.Widgets.Feeds.Providers/setup.py
+++ b/projection/winrt-Microsoft.Windows.Widgets.Feeds.Providers/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.Widgets.Providers/setup.py
+++ b/projection/winrt-Microsoft.Windows.Widgets.Providers/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Microsoft.Windows.Widgets/setup.py
+++ b/projection/winrt-Microsoft.Windows.Widgets/setup.py
@@ -10,9 +10,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-TestComponent/setup.py
+++ b/projection/winrt-TestComponent/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.AI.MachineLearning.Preview/setup.py
+++ b/projection/winrt-Windows.AI.MachineLearning.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.AI.MachineLearning/setup.py
+++ b/projection/winrt-Windows.AI.MachineLearning/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Activation/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Activation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.AppExtensions/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.AppExtensions/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.AppService/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.AppService/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Appointments.AppointmentsProvider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Appointments.AppointmentsProvider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Appointments.DataProvider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Appointments.DataProvider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Appointments/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Appointments/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Background/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Background/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Calls.Background/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Calls.Background/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Calls.Provider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Calls.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Calls/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Calls/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Chat/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Chat/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.CommunicationBlocking/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.CommunicationBlocking/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Contacts.DataProvider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Contacts.DataProvider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Contacts.Provider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Contacts.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Contacts/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Contacts/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.ConversationalAgent/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.ConversationalAgent/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Core/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.DataTransfer.DragDrop.Core/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.DataTransfer.DragDrop.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.DataTransfer.DragDrop/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.DataTransfer.DragDrop/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.DataTransfer.ShareTarget/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.DataTransfer.ShareTarget/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.DataTransfer/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.DataTransfer/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Email.DataProvider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Email.DataProvider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Email/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Email/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.ExtendedExecution.Foreground/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.ExtendedExecution.Foreground/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.ExtendedExecution/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.ExtendedExecution/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Holographic/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Holographic/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.LockScreen/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.LockScreen/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Payments.Provider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Payments.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Payments/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Payments/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Preview.Holographic/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Preview.Holographic/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Preview.InkWorkspace/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Preview.InkWorkspace/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Preview.Notes/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Preview.Notes/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Resources.Core/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Resources.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Resources.Management/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Resources.Management/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Resources/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Resources/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Search.Core/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Search.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Search/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Search/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.SocialInfo.Provider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.SocialInfo.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.SocialInfo/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.SocialInfo/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Store.LicenseManagement/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Store.LicenseManagement/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Store.Preview.InstallControl/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Store.Preview.InstallControl/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Store.Preview/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Store.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Store/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Store/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.UserActivities.Core/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.UserActivities.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.UserActivities/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.UserActivities/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.UserDataAccounts.Provider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.UserDataAccounts.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.UserDataAccounts.SystemAccess/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.UserDataAccounts.SystemAccess/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.UserDataAccounts/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.UserDataAccounts/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.UserDataTasks.DataProvider/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.UserDataTasks.DataProvider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.UserDataTasks/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.UserDataTasks/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.VoiceCommands/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.VoiceCommands/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Wallet.System/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Wallet.System/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel.Wallet/setup.py
+++ b/projection/winrt-Windows.ApplicationModel.Wallet/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.ApplicationModel/setup.py
+++ b/projection/winrt-Windows.ApplicationModel/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Data.Html/setup.py
+++ b/projection/winrt-Windows.Data.Html/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Data.Json/setup.py
+++ b/projection/winrt-Windows.Data.Json/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Data.Pdf/setup.py
+++ b/projection/winrt-Windows.Data.Pdf/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Data.Text/setup.py
+++ b/projection/winrt-Windows.Data.Text/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Data.Xml.Dom/setup.py
+++ b/projection/winrt-Windows.Data.Xml.Dom/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Data.Xml.Xsl/setup.py
+++ b/projection/winrt-Windows.Data.Xml.Xsl/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Adc.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.Adc.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Adc/setup.py
+++ b/projection/winrt-Windows.Devices.Adc/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.AllJoyn/setup.py
+++ b/projection/winrt-Windows.Devices.AllJoyn/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Background/setup.py
+++ b/projection/winrt-Windows.Devices.Background/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Bluetooth.Advertisement/setup.py
+++ b/projection/winrt-Windows.Devices.Bluetooth.Advertisement/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Bluetooth.Background/setup.py
+++ b/projection/winrt-Windows.Devices.Bluetooth.Background/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Bluetooth.GenericAttributeProfile/setup.py
+++ b/projection/winrt-Windows.Devices.Bluetooth.GenericAttributeProfile/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Bluetooth.Rfcomm/setup.py
+++ b/projection/winrt-Windows.Devices.Bluetooth.Rfcomm/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Bluetooth/setup.py
+++ b/projection/winrt-Windows.Devices.Bluetooth/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Custom/setup.py
+++ b/projection/winrt-Windows.Devices.Custom/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Display.Core/setup.py
+++ b/projection/winrt-Windows.Devices.Display.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Display/setup.py
+++ b/projection/winrt-Windows.Devices.Display/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Enumeration.Pnp/setup.py
+++ b/projection/winrt-Windows.Devices.Enumeration.Pnp/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Enumeration/setup.py
+++ b/projection/winrt-Windows.Devices.Enumeration/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Geolocation.Geofencing/setup.py
+++ b/projection/winrt-Windows.Devices.Geolocation.Geofencing/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Geolocation.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.Geolocation.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Geolocation/setup.py
+++ b/projection/winrt-Windows.Devices.Geolocation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Gpio.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.Gpio.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Gpio/setup.py
+++ b/projection/winrt-Windows.Devices.Gpio/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Haptics/setup.py
+++ b/projection/winrt-Windows.Devices.Haptics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.HumanInterfaceDevice/setup.py
+++ b/projection/winrt-Windows.Devices.HumanInterfaceDevice/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.I2c.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.I2c.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.I2c/setup.py
+++ b/projection/winrt-Windows.Devices.I2c/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Input.Preview/setup.py
+++ b/projection/winrt-Windows.Devices.Input.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Input/setup.py
+++ b/projection/winrt-Windows.Devices.Input/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Lights.Effects/setup.py
+++ b/projection/winrt-Windows.Devices.Lights.Effects/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Lights/setup.py
+++ b/projection/winrt-Windows.Devices.Lights/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Midi/setup.py
+++ b/projection/winrt-Windows.Devices.Midi/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Perception.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.Perception.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Perception/setup.py
+++ b/projection/winrt-Windows.Devices.Perception/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.PointOfService.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.PointOfService.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.PointOfService/setup.py
+++ b/projection/winrt-Windows.Devices.PointOfService/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Portable/setup.py
+++ b/projection/winrt-Windows.Devices.Portable/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Power/setup.py
+++ b/projection/winrt-Windows.Devices.Power/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Printers.Extensions/setup.py
+++ b/projection/winrt-Windows.Devices.Printers.Extensions/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Printers/setup.py
+++ b/projection/winrt-Windows.Devices.Printers/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Pwm.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.Pwm.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Pwm/setup.py
+++ b/projection/winrt-Windows.Devices.Pwm/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Radios/setup.py
+++ b/projection/winrt-Windows.Devices.Radios/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Scanners/setup.py
+++ b/projection/winrt-Windows.Devices.Scanners/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Sensors.Custom/setup.py
+++ b/projection/winrt-Windows.Devices.Sensors.Custom/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Sensors/setup.py
+++ b/projection/winrt-Windows.Devices.Sensors/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.SerialCommunication/setup.py
+++ b/projection/winrt-Windows.Devices.SerialCommunication/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.SmartCards/setup.py
+++ b/projection/winrt-Windows.Devices.SmartCards/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Sms/setup.py
+++ b/projection/winrt-Windows.Devices.Sms/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Spi.Provider/setup.py
+++ b/projection/winrt-Windows.Devices.Spi.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Spi/setup.py
+++ b/projection/winrt-Windows.Devices.Spi/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.Usb/setup.py
+++ b/projection/winrt-Windows.Devices.Usb/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.WiFi/setup.py
+++ b/projection/winrt-Windows.Devices.WiFi/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.WiFiDirect.Services/setup.py
+++ b/projection/winrt-Windows.Devices.WiFiDirect.Services/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices.WiFiDirect/setup.py
+++ b/projection/winrt-Windows.Devices.WiFiDirect/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Devices/setup.py
+++ b/projection/winrt-Windows.Devices/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Embedded.DeviceLockdown/setup.py
+++ b/projection/winrt-Windows.Embedded.DeviceLockdown/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Foundation.Collections/setup.py
+++ b/projection/winrt-Windows.Foundation.Collections/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Foundation.Diagnostics/setup.py
+++ b/projection/winrt-Windows.Foundation.Diagnostics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Foundation.Metadata/setup.py
+++ b/projection/winrt-Windows.Foundation.Metadata/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Foundation.Numerics/setup.py
+++ b/projection/winrt-Windows.Foundation.Numerics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Foundation/setup.py
+++ b/projection/winrt-Windows.Foundation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Gaming.Input.Custom/setup.py
+++ b/projection/winrt-Windows.Gaming.Input.Custom/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Gaming.Input.ForceFeedback/setup.py
+++ b/projection/winrt-Windows.Gaming.Input.ForceFeedback/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Gaming.Input.Preview/setup.py
+++ b/projection/winrt-Windows.Gaming.Input.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Gaming.Input/setup.py
+++ b/projection/winrt-Windows.Gaming.Input/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Gaming.Preview.GamesEnumeration/setup.py
+++ b/projection/winrt-Windows.Gaming.Preview.GamesEnumeration/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Gaming.UI/setup.py
+++ b/projection/winrt-Windows.Gaming.UI/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Gaming.XboxLive.Storage/setup.py
+++ b/projection/winrt-Windows.Gaming.XboxLive.Storage/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Globalization.Collation/setup.py
+++ b/projection/winrt-Windows.Globalization.Collation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Globalization.DateTimeFormatting/setup.py
+++ b/projection/winrt-Windows.Globalization.DateTimeFormatting/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Globalization.Fonts/setup.py
+++ b/projection/winrt-Windows.Globalization.Fonts/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Globalization.NumberFormatting/setup.py
+++ b/projection/winrt-Windows.Globalization.NumberFormatting/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Globalization.PhoneNumberFormatting/setup.py
+++ b/projection/winrt-Windows.Globalization.PhoneNumberFormatting/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Globalization/setup.py
+++ b/projection/winrt-Windows.Globalization/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Capture/setup.py
+++ b/projection/winrt-Windows.Graphics.Capture/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.DirectX.Direct3D11/setup.py
+++ b/projection/winrt-Windows.Graphics.DirectX.Direct3D11/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.DirectX/setup.py
+++ b/projection/winrt-Windows.Graphics.DirectX/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Display.Core/setup.py
+++ b/projection/winrt-Windows.Graphics.Display.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Display/setup.py
+++ b/projection/winrt-Windows.Graphics.Display/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Effects/setup.py
+++ b/projection/winrt-Windows.Graphics.Effects/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Holographic/setup.py
+++ b/projection/winrt-Windows.Graphics.Holographic/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Imaging/setup.py
+++ b/projection/winrt-Windows.Graphics.Imaging/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Printing.OptionDetails/setup.py
+++ b/projection/winrt-Windows.Graphics.Printing.OptionDetails/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Printing.PrintSupport/setup.py
+++ b/projection/winrt-Windows.Graphics.Printing.PrintSupport/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Printing.PrintTicket/setup.py
+++ b/projection/winrt-Windows.Graphics.Printing.PrintTicket/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Printing.Workflow/setup.py
+++ b/projection/winrt-Windows.Graphics.Printing.Workflow/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Printing/setup.py
+++ b/projection/winrt-Windows.Graphics.Printing/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics.Printing3D/setup.py
+++ b/projection/winrt-Windows.Graphics.Printing3D/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Graphics/setup.py
+++ b/projection/winrt-Windows.Graphics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Management.Core/setup.py
+++ b/projection/winrt-Windows.Management.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Management.Deployment.Preview/setup.py
+++ b/projection/winrt-Windows.Management.Deployment.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Management.Deployment/setup.py
+++ b/projection/winrt-Windows.Management.Deployment/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Management.Policies/setup.py
+++ b/projection/winrt-Windows.Management.Policies/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Management.Update/setup.py
+++ b/projection/winrt-Windows.Management.Update/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Management.Workplace/setup.py
+++ b/projection/winrt-Windows.Management.Workplace/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Management/setup.py
+++ b/projection/winrt-Windows.Management/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.AppBroadcasting/setup.py
+++ b/projection/winrt-Windows.Media.AppBroadcasting/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.AppRecording/setup.py
+++ b/projection/winrt-Windows.Media.AppRecording/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Audio/setup.py
+++ b/projection/winrt-Windows.Media.Audio/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Capture.Core/setup.py
+++ b/projection/winrt-Windows.Media.Capture.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Capture.Frames/setup.py
+++ b/projection/winrt-Windows.Media.Capture.Frames/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Capture/setup.py
+++ b/projection/winrt-Windows.Media.Capture/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Casting/setup.py
+++ b/projection/winrt-Windows.Media.Casting/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.ClosedCaptioning/setup.py
+++ b/projection/winrt-Windows.Media.ClosedCaptioning/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.ContentRestrictions/setup.py
+++ b/projection/winrt-Windows.Media.ContentRestrictions/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Control/setup.py
+++ b/projection/winrt-Windows.Media.Control/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Core.Preview/setup.py
+++ b/projection/winrt-Windows.Media.Core.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Core/setup.py
+++ b/projection/winrt-Windows.Media.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Devices.Core/setup.py
+++ b/projection/winrt-Windows.Media.Devices.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Devices/setup.py
+++ b/projection/winrt-Windows.Media.Devices/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.DialProtocol/setup.py
+++ b/projection/winrt-Windows.Media.DialProtocol/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Editing/setup.py
+++ b/projection/winrt-Windows.Media.Editing/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Effects/setup.py
+++ b/projection/winrt-Windows.Media.Effects/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.FaceAnalysis/setup.py
+++ b/projection/winrt-Windows.Media.FaceAnalysis/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Import/setup.py
+++ b/projection/winrt-Windows.Media.Import/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.MediaProperties/setup.py
+++ b/projection/winrt-Windows.Media.MediaProperties/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Miracast/setup.py
+++ b/projection/winrt-Windows.Media.Miracast/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Ocr/setup.py
+++ b/projection/winrt-Windows.Media.Ocr/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.PlayTo/setup.py
+++ b/projection/winrt-Windows.Media.PlayTo/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Playback/setup.py
+++ b/projection/winrt-Windows.Media.Playback/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Playlists/setup.py
+++ b/projection/winrt-Windows.Media.Playlists/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Protection.PlayReady/setup.py
+++ b/projection/winrt-Windows.Media.Protection.PlayReady/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Protection/setup.py
+++ b/projection/winrt-Windows.Media.Protection/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Render/setup.py
+++ b/projection/winrt-Windows.Media.Render/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.SpeechRecognition/setup.py
+++ b/projection/winrt-Windows.Media.SpeechRecognition/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.SpeechSynthesis/setup.py
+++ b/projection/winrt-Windows.Media.SpeechSynthesis/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Streaming.Adaptive/setup.py
+++ b/projection/winrt-Windows.Media.Streaming.Adaptive/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media.Transcoding/setup.py
+++ b/projection/winrt-Windows.Media.Transcoding/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Media/setup.py
+++ b/projection/winrt-Windows.Media/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.BackgroundTransfer/setup.py
+++ b/projection/winrt-Windows.Networking.BackgroundTransfer/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.Connectivity/setup.py
+++ b/projection/winrt-Windows.Networking.Connectivity/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.NetworkOperators/setup.py
+++ b/projection/winrt-Windows.Networking.NetworkOperators/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.Proximity/setup.py
+++ b/projection/winrt-Windows.Networking.Proximity/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.PushNotifications/setup.py
+++ b/projection/winrt-Windows.Networking.PushNotifications/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.ServiceDiscovery.Dnssd/setup.py
+++ b/projection/winrt-Windows.Networking.ServiceDiscovery.Dnssd/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.Sockets/setup.py
+++ b/projection/winrt-Windows.Networking.Sockets/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.Vpn/setup.py
+++ b/projection/winrt-Windows.Networking.Vpn/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking.XboxLive/setup.py
+++ b/projection/winrt-Windows.Networking.XboxLive/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Networking/setup.py
+++ b/projection/winrt-Windows.Networking/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Perception.Automation.Core/setup.py
+++ b/projection/winrt-Windows.Perception.Automation.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Perception.People/setup.py
+++ b/projection/winrt-Windows.Perception.People/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Perception.Spatial.Preview/setup.py
+++ b/projection/winrt-Windows.Perception.Spatial.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Perception.Spatial.Surfaces/setup.py
+++ b/projection/winrt-Windows.Perception.Spatial.Surfaces/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Perception.Spatial/setup.py
+++ b/projection/winrt-Windows.Perception.Spatial/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Perception/setup.py
+++ b/projection/winrt-Windows.Perception/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.ApplicationModel/setup.py
+++ b/projection/winrt-Windows.Phone.ApplicationModel/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.Devices.Notification/setup.py
+++ b/projection/winrt-Windows.Phone.Devices.Notification/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.Devices.Power/setup.py
+++ b/projection/winrt-Windows.Phone.Devices.Power/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.Management.Deployment/setup.py
+++ b/projection/winrt-Windows.Phone.Management.Deployment/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.Media.Devices/setup.py
+++ b/projection/winrt-Windows.Phone.Media.Devices/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.Notification.Management/setup.py
+++ b/projection/winrt-Windows.Phone.Notification.Management/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.PersonalInformation.Provisioning/setup.py
+++ b/projection/winrt-Windows.Phone.PersonalInformation.Provisioning/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.PersonalInformation/setup.py
+++ b/projection/winrt-Windows.Phone.PersonalInformation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.Speech.Recognition/setup.py
+++ b/projection/winrt-Windows.Phone.Speech.Recognition/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.StartScreen/setup.py
+++ b/projection/winrt-Windows.Phone.StartScreen/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.System.Power/setup.py
+++ b/projection/winrt-Windows.Phone.System.Power/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.System.Profile/setup.py
+++ b/projection/winrt-Windows.Phone.System.Profile/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.System.UserProfile.GameServices.Core/setup.py
+++ b/projection/winrt-Windows.Phone.System.UserProfile.GameServices.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.System/setup.py
+++ b/projection/winrt-Windows.Phone.System/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Phone.UI.Input/setup.py
+++ b/projection/winrt-Windows.Phone.UI.Input/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authentication.Identity.Core/setup.py
+++ b/projection/winrt-Windows.Security.Authentication.Identity.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authentication.Identity.Provider/setup.py
+++ b/projection/winrt-Windows.Security.Authentication.Identity.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authentication.Identity/setup.py
+++ b/projection/winrt-Windows.Security.Authentication.Identity/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authentication.OnlineId/setup.py
+++ b/projection/winrt-Windows.Security.Authentication.OnlineId/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authentication.Web.Core/setup.py
+++ b/projection/winrt-Windows.Security.Authentication.Web.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authentication.Web.Provider/setup.py
+++ b/projection/winrt-Windows.Security.Authentication.Web.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authentication.Web/setup.py
+++ b/projection/winrt-Windows.Security.Authentication.Web/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Authorization.AppCapabilityAccess/setup.py
+++ b/projection/winrt-Windows.Security.Authorization.AppCapabilityAccess/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Credentials.UI/setup.py
+++ b/projection/winrt-Windows.Security.Credentials.UI/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Credentials/setup.py
+++ b/projection/winrt-Windows.Security.Credentials/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Cryptography.Certificates/setup.py
+++ b/projection/winrt-Windows.Security.Cryptography.Certificates/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Cryptography.Core/setup.py
+++ b/projection/winrt-Windows.Security.Cryptography.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Cryptography.DataProtection/setup.py
+++ b/projection/winrt-Windows.Security.Cryptography.DataProtection/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Cryptography/setup.py
+++ b/projection/winrt-Windows.Security.Cryptography/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.DataProtection/setup.py
+++ b/projection/winrt-Windows.Security.DataProtection/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.EnterpriseData/setup.py
+++ b/projection/winrt-Windows.Security.EnterpriseData/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.ExchangeActiveSyncProvisioning/setup.py
+++ b/projection/winrt-Windows.Security.ExchangeActiveSyncProvisioning/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Security.Isolation/setup.py
+++ b/projection/winrt-Windows.Security.Isolation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Services.Cortana/setup.py
+++ b/projection/winrt-Windows.Services.Cortana/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Services.Maps.Guidance/setup.py
+++ b/projection/winrt-Windows.Services.Maps.Guidance/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Services.Maps.LocalSearch/setup.py
+++ b/projection/winrt-Windows.Services.Maps.LocalSearch/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Services.Maps.OfflineMaps/setup.py
+++ b/projection/winrt-Windows.Services.Maps.OfflineMaps/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Services.Maps/setup.py
+++ b/projection/winrt-Windows.Services.Maps/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Services.Store/setup.py
+++ b/projection/winrt-Windows.Services.Store/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Services.TargetedContent/setup.py
+++ b/projection/winrt-Windows.Services.TargetedContent/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.AccessCache/setup.py
+++ b/projection/winrt-Windows.Storage.AccessCache/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.BulkAccess/setup.py
+++ b/projection/winrt-Windows.Storage.BulkAccess/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.Compression/setup.py
+++ b/projection/winrt-Windows.Storage.Compression/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.FileProperties/setup.py
+++ b/projection/winrt-Windows.Storage.FileProperties/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.Pickers.Provider/setup.py
+++ b/projection/winrt-Windows.Storage.Pickers.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.Pickers/setup.py
+++ b/projection/winrt-Windows.Storage.Pickers/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.Provider/setup.py
+++ b/projection/winrt-Windows.Storage.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.Search/setup.py
+++ b/projection/winrt-Windows.Storage.Search/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage.Streams/setup.py
+++ b/projection/winrt-Windows.Storage.Streams/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Storage/setup.py
+++ b/projection/winrt-Windows.Storage/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Diagnostics.DevicePortal/setup.py
+++ b/projection/winrt-Windows.System.Diagnostics.DevicePortal/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Diagnostics.Telemetry/setup.py
+++ b/projection/winrt-Windows.System.Diagnostics.Telemetry/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Diagnostics.TraceReporting/setup.py
+++ b/projection/winrt-Windows.System.Diagnostics.TraceReporting/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Diagnostics/setup.py
+++ b/projection/winrt-Windows.System.Diagnostics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Display/setup.py
+++ b/projection/winrt-Windows.System.Display/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Implementation.FileExplorer/setup.py
+++ b/projection/winrt-Windows.System.Implementation.FileExplorer/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Inventory/setup.py
+++ b/projection/winrt-Windows.System.Inventory/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Power.Diagnostics/setup.py
+++ b/projection/winrt-Windows.System.Power.Diagnostics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Power/setup.py
+++ b/projection/winrt-Windows.System.Power/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Preview/setup.py
+++ b/projection/winrt-Windows.System.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Profile.SystemManufacturers/setup.py
+++ b/projection/winrt-Windows.System.Profile.SystemManufacturers/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Profile/setup.py
+++ b/projection/winrt-Windows.System.Profile/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.RemoteDesktop.Input/setup.py
+++ b/projection/winrt-Windows.System.RemoteDesktop.Input/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.RemoteDesktop.Provider/setup.py
+++ b/projection/winrt-Windows.System.RemoteDesktop.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.RemoteDesktop/setup.py
+++ b/projection/winrt-Windows.System.RemoteDesktop/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.RemoteSystems/setup.py
+++ b/projection/winrt-Windows.System.RemoteSystems/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Threading.Core/setup.py
+++ b/projection/winrt-Windows.System.Threading.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Threading/setup.py
+++ b/projection/winrt-Windows.System.Threading/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.Update/setup.py
+++ b/projection/winrt-Windows.System.Update/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System.UserProfile/setup.py
+++ b/projection/winrt-Windows.System.UserProfile/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.System/setup.py
+++ b/projection/winrt-Windows.System/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Accessibility/setup.py
+++ b/projection/winrt-Windows.UI.Accessibility/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.ApplicationSettings/setup.py
+++ b/projection/winrt-Windows.UI.ApplicationSettings/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Composition.Core/setup.py
+++ b/projection/winrt-Windows.UI.Composition.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Composition.Desktop/setup.py
+++ b/projection/winrt-Windows.UI.Composition.Desktop/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Composition.Diagnostics/setup.py
+++ b/projection/winrt-Windows.UI.Composition.Diagnostics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Composition.Effects/setup.py
+++ b/projection/winrt-Windows.UI.Composition.Effects/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Composition.Interactions/setup.py
+++ b/projection/winrt-Windows.UI.Composition.Interactions/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Composition.Scenes/setup.py
+++ b/projection/winrt-Windows.UI.Composition.Scenes/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Composition/setup.py
+++ b/projection/winrt-Windows.UI.Composition/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Core.AnimationMetrics/setup.py
+++ b/projection/winrt-Windows.UI.Core.AnimationMetrics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Core.Preview.Communications/setup.py
+++ b/projection/winrt-Windows.UI.Core.Preview.Communications/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Core.Preview/setup.py
+++ b/projection/winrt-Windows.UI.Core.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Core/setup.py
+++ b/projection/winrt-Windows.UI.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Core/setup.py
+++ b/projection/winrt-Windows.UI.Input.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Inking.Analysis/setup.py
+++ b/projection/winrt-Windows.UI.Input.Inking.Analysis/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Inking.Core/setup.py
+++ b/projection/winrt-Windows.UI.Input.Inking.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Inking.Preview/setup.py
+++ b/projection/winrt-Windows.UI.Input.Inking.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Inking/setup.py
+++ b/projection/winrt-Windows.UI.Input.Inking/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Preview.Injection/setup.py
+++ b/projection/winrt-Windows.UI.Input.Preview.Injection/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Preview/setup.py
+++ b/projection/winrt-Windows.UI.Input.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input.Spatial/setup.py
+++ b/projection/winrt-Windows.UI.Input.Spatial/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Input/setup.py
+++ b/projection/winrt-Windows.UI.Input/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Notifications.Management/setup.py
+++ b/projection/winrt-Windows.UI.Notifications.Management/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Notifications.Preview/setup.py
+++ b/projection/winrt-Windows.UI.Notifications.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Notifications/setup.py
+++ b/projection/winrt-Windows.UI.Notifications/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Popups/setup.py
+++ b/projection/winrt-Windows.UI.Popups/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Shell/setup.py
+++ b/projection/winrt-Windows.UI.Shell/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.StartScreen/setup.py
+++ b/projection/winrt-Windows.UI.StartScreen/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Text.Core/setup.py
+++ b/projection/winrt-Windows.UI.Text.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Text/setup.py
+++ b/projection/winrt-Windows.UI.Text/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.UIAutomation.Core/setup.py
+++ b/projection/winrt-Windows.UI.UIAutomation.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.UIAutomation/setup.py
+++ b/projection/winrt-Windows.UI.UIAutomation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.ViewManagement.Core/setup.py
+++ b/projection/winrt-Windows.UI.ViewManagement.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.ViewManagement/setup.py
+++ b/projection/winrt-Windows.UI.ViewManagement/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.WebUI.Core/setup.py
+++ b/projection/winrt-Windows.UI.WebUI.Core/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.WebUI/setup.py
+++ b/projection/winrt-Windows.UI.WebUI/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.WindowManagement.Preview/setup.py
+++ b/projection/winrt-Windows.UI.WindowManagement.Preview/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.WindowManagement/setup.py
+++ b/projection/winrt-Windows.UI.WindowManagement/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Automation.Peers/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Automation.Peers/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Automation.Provider/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Automation.Provider/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Automation.Text/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Automation.Text/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Automation/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Automation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Controls.Maps/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Controls.Maps/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Controls.Primitives/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Controls.Primitives/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Controls/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Controls/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Core.Direct/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Core.Direct/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Data/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Data/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Documents/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Documents/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Hosting/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Hosting/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Input/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Input/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Interop/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Interop/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Markup/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Markup/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Media.Animation/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Media.Animation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Media.Imaging/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Media.Imaging/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Media.Media3D/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Media.Media3D/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Media/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Media/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Navigation/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Navigation/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Printing/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Printing/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Resources/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Resources/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml.Shapes/setup.py
+++ b/projection/winrt-Windows.UI.Xaml.Shapes/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI.Xaml/setup.py
+++ b/projection/winrt-Windows.UI.Xaml/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.UI/setup.py
+++ b/projection/winrt-Windows.UI/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.AtomPub/setup.py
+++ b/projection/winrt-Windows.Web.AtomPub/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.Http.Diagnostics/setup.py
+++ b/projection/winrt-Windows.Web.Http.Diagnostics/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.Http.Filters/setup.py
+++ b/projection/winrt-Windows.Web.Http.Filters/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.Http.Headers/setup.py
+++ b/projection/winrt-Windows.Web.Http.Headers/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.Http/setup.py
+++ b/projection/winrt-Windows.Web.Http/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.Syndication/setup.py
+++ b/projection/winrt-Windows.Web.Syndication/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.UI.Interop/setup.py
+++ b/projection/winrt-Windows.Web.UI.Interop/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web.UI/setup.py
+++ b/projection/winrt-Windows.Web.UI/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-Windows.Web/setup.py
+++ b/projection/winrt-Windows.Web/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/projection/winrt-runtime/setup.py
+++ b/projection/winrt-runtime/setup.py
@@ -9,9 +9,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {self.compiler.compiler_type}")
 
         build_ext.build_extension(self, ext)
 

--- a/scripts/generate-pyproject.py
+++ b/scripts/generate-pyproject.py
@@ -80,9 +80,11 @@ class build_ext_ex(build_ext):
     def build_extension(self, ext):
         if self.compiler.compiler_type == "msvc":
             ext.extra_compile_args = ["/std:c++20", "/permissive-"]
-        else:
-            ext.extra_compile_args = ["-std=c++20"]
+        elif self.compiler.compiler_type == "mingw32":
+            ext.extra_compile_args = ["-std=c++20", "-D_WIN32_WINNT=_WIN32_WINNT_WIN10"]
             ext.extra_link_args = ["-loleaut32"]
+        else:
+            raise ValueError(f"Unsupported compiler: {{self.compiler.compiler_type}}")
 
         build_ext.build_extension(self, ext)
 


### PR DESCRIPTION
gcc on MINGW64 needs and extra define to tell headers that we are targeting Windows 10 and above.

Also move everything non-msvc into a mingw32 check since other compilers are not tested.

Fixes: https://github.com/pywinrt/pywinrt/issues/46