### PR TITLE
projection: release GIL in Application.start()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed `TypeError` when trying to pass composed runtime object to API that
   requires subclass ([#25]).
 - Fixed `TypeError` when passing `None` to APIs that require a `system.Object`.
+- Fixed `ui.xaml.Application.start()` methods not releasing GIL.
 
 [#25]: https://github.com/pywinrt/pywinrt/issues/25
 

--- a/projection/winrt-Microsoft.UI.Xaml/py.Microsoft.UI.Xaml.cpp
+++ b/projection/winrt-Microsoft.UI.Xaml/py.Microsoft.UI.Xaml.cpp
@@ -398,7 +398,10 @@ namespace py::cpp::Microsoft::UI::Xaml
 
                 auto param0 = py::convert_to<winrt::Microsoft::UI::Xaml::ApplicationInitializationCallback>(args, 0);
 
-                winrt::Microsoft::UI::Xaml::Application::Start(param0);
+                {
+                    auto ts = release_gil();
+                    winrt::Microsoft::UI::Xaml::Application::Start(param0);
+                }
                 Py_RETURN_NONE;
             }
             catch (...)

--- a/projection/winrt-Windows.UI.Xaml/py.Windows.UI.Xaml.cpp
+++ b/projection/winrt-Windows.UI.Xaml/py.Windows.UI.Xaml.cpp
@@ -398,7 +398,10 @@ namespace py::cpp::Windows::UI::Xaml
 
                 auto param0 = py::convert_to<winrt::Windows::UI::Xaml::ApplicationInitializationCallback>(args, 0);
 
-                winrt::Windows::UI::Xaml::Application::Start(param0);
+                {
+                    auto ts = release_gil();
+                    winrt::Windows::UI::Xaml::Application::Start(param0);
+                }
                 Py_RETURN_NONE;
             }
             catch (...)

--- a/projection/winrt-sdk/src/winrt_sdk/pywinrt/pybase.h
+++ b/projection/winrt-sdk/src/winrt_sdk/pywinrt/pybase.h
@@ -63,6 +63,37 @@ namespace py
         return gil_handle{PyGILState_Ensure()};
     }
 
+    /**
+     * Traits for use with winrt::handle_type.
+     */
+    struct thread_state_traits
+    {
+        using type = PyThreadState*;
+
+        static void close(type value) noexcept
+        {
+            PyEval_RestoreThread(value);
+        }
+
+        static constexpr type invalid() noexcept
+        {
+            return nullptr;
+        }
+    };
+
+    /**
+     * Type alias for Python thread state handle.
+     */
+    using thread_state_handle = winrt::handle_type<thread_state_traits>;
+
+    /**
+     * Helper function for ensuring a block of code runs with the Python GIL released.
+     */
+    static inline auto release_gil()
+    {
+        return thread_state_handle{PyEval_SaveThread()};
+    }
+
     template<typename Category>
     struct pinterface_checker
     {


### PR DESCRIPTION
The Application.start() methods are long running since they pump events for the application. So we need to release the GIL to allow other Python threads to run.

Since these are the only known methods that need to release the GIL, we just hack in a special test for them.