### PR TITLE
projection/CMakeLists: workaround mingw header bug

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ on:
       - '!projection/**/*.toml'
       - '!projection/**/*.txt'
       - '!projection/**/setup.py'
+      - projection/CMakeLists.txt
       - test/**
 
 jobs:

--- a/projection/CMakeLists.txt
+++ b/projection/CMakeLists.txt
@@ -21,6 +21,10 @@ else()
         add_definitions(-D_WIN32_WINNT=_WIN32_WINNT_WIN10)
         # fixes "file too big"
         add_compile_options(-Wa,-mbig-obj)
+
+        # work around bad generated headers
+        # https://github.com/msys2/MINGW-packages/issues/22160
+        add_definitions(-D____FIReference_1_boolean_INTERFACE_DEFINED__)
     endif()
 endif()
 


### PR DESCRIPTION
Avoids duplicate definition as described in https://github.com/msys2/MINGW-packages/issues/22160