### PR TITLE
github: drop -dev from Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', "3.11", "3.12", "3.13-dev"]
+        python-version: ['3.9', '3.10', "3.11", "3.12", "3.13"]
         architecture: ['x86', 'x64']
         release-type: ['Release'] # no "Debug" - https://github.com/actions/setup-python/issues/86
         include:


### PR DESCRIPTION
Stable release is out now.