### PR TITLE
Don't mark used variable as discarded in iunknown.py

### DIFF
--- a/samples/screen_capture/iunknown.py
+++ b/samples/screen_capture/iunknown.py
@@ -27,8 +27,8 @@ class IUnknown(ctypes.c_void_p):
             iid = uuid.UUID(iid)
 
         ppv = wintypes.LPVOID()
-        _iid = GUID.from_buffer_copy(iid.bytes_le)
-        ret = self.QueryInterface(self, ctypes.byref(_iid), ctypes.byref(ppv))
+        riid = GUID.from_buffer_copy(iid.bytes_le)
+        ret = self.QueryInterface(self, ctypes.byref(riid), ctypes.byref(ppv))
 
         if ret.value:
             raise ctypes.WinError(ret.value)


### PR DESCRIPTION
The prefix `_` was almost certainly added to differentiate `_iid: GUID` from `iid: UUID | str` which would cause static type-checkers issues when re-assigning an incompatible type.

however, prefixing an assigned variable with `_` is often used as a "discard/unused" marker. Triggering linter rules such as [used-dummy-variable (RUF052)](https://docs.astral.sh/ruff/rules/used-dummy-variable/#used-dummy-variable-ruf052). This is a simple change to make this code more usable "out of the box" when added to existing codebases.

I went with `riid` as the name as per https://learn.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)

even without linter concerns, I think this is a small improvement to the variable name.