### PR TITLE
projection: make wrap_async internal and change implementation

### DIFF
--- a/docs/api/system.rst
+++ b/docs/api/system.rst
@@ -155,29 +155,3 @@ be unboxed to get the original value.
         value = obj.as_(IPropertyValue).get_xyz()
 
     .. versionadded:: 3.0
-
-
------
-Async
------
-
-The WinRT projection is integrated with Python's :mod:`asyncio` module. This
-is mostly transparent, but there is one helper function available.
-
-.. function:: wrap_async(op: winrt.windows.foundation.IAsyncAction) -> asyncio.Future[None]
-    wrap_async(op: winrt.windows.foundation.IAsyncOperation[T]) -> asyncio.Future[T]
-
-    Wraps a WinRT asynchronous operation in :class:`asyncio.Future`.
-
-    This also works with the ``WithProgress`` variants of the interfaces.
-
-    This is only needed when you need access to the :class:`asyncio.Future`
-    object, otherwise you can ``await`` the operation directly.
-
-    :param op: The WinRT asynchronous operation to wrap.
-    :return: An :class:`asyncio.Future` that will be completed when the
-        operation is finished.
-
-    .. versionadded:: unreleased
-
-.. seealso:: :ref:`async-projection` in the PyWinRT projection/types documentation.

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -327,21 +327,9 @@ for the result of async WinRT methods::
 
     thing = await winrt_obj.get_thing_async()
 
-This is the same as calling::
-
-    from winrt.system import wrap_async
-
-    thing = await wrap_async(winrt_obj.get_thing_async())
-
-:func:`winrt.system.wrap_async` is a helper function that wraps the WinRT async
-operation in a :class:`asyncio.Future` object. Generally, awaiting directly is
-more convenient, but if you need a future-like object instead of an awaitable,
-you can use this function to get the actual ``Future`` object. However, using
-structured async programming patterns is preferred.
-
 .. versionchanged:: unreleased
 
-    If the :class:`asyncio.Future` that wraps the operation is canceled, it will
+    If the :class:`asyncio.Awaitable` that wraps the operation is canceled, it will
     now propagate the cancellation to the WinRT async action/operation. To restore
     the previous behavior, you can wrap the operation in :func:`asyncio.shield`.
 

--- a/projection/winrt-runtime/src/winrt/runtime/_internals.py
+++ b/projection/winrt-runtime/src/winrt/runtime/_internals.py
@@ -1,0 +1,66 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar, Protocol, TYPE_CHECKING
+
+from typing_extensions import Self
+
+# Unfortunately, we can't import at runtime because of circular imports.
+if TYPE_CHECKING:
+    from winrt.windows.foundation import HResult, AsyncStatus
+
+
+T = TypeVar("T")
+
+
+# MyPy wants covariant T but Pylance wants invariant. Invariant seems correct.
+class AsyncOp(Protocol[T]):  # type: ignore [misc]
+    """
+    Protocol that matches both IAsyncAction and IAsyncOperation.
+    """
+
+    def cancel(self) -> None: ...
+    @property
+    def error_code(self) -> "HResult": ...
+    @property
+    def status(self) -> "AsyncStatus": ...
+    def get_results(self) -> T: ...
+    @property
+    def completed(self) -> Callable[[Self, "AsyncStatus"], None]: ...
+    @completed.setter
+    def completed(self, value: Callable[[Self, "AsyncStatus"], None]) -> None: ...
+
+
+def wrap_async(op: AsyncOp[T]) -> Awaitable[T]:
+    """
+    Wraps a WinRT async operation in a Python Awaitable.
+
+    This is used by the runtime to implement ``__await__`` on async operations.
+
+    Args:
+        op: The WinRT async operation to wrap.
+
+    Returns:
+        An asyncio Awaitable that will be completed when the WinRT operation
+        completes.
+    """
+
+    async def wait() -> T:
+        loop = asyncio.get_running_loop()
+        event = asyncio.Event()
+
+        def on_complete(op: AsyncOp[T], status: "AsyncStatus") -> None:
+            loop.call_soon_threadsafe(event.set)
+
+        op.completed = on_complete
+
+        try:
+            await event.wait()
+        except asyncio.CancelledError:
+            op.cancel()
+            # REVISIT: what if it is cancelled again?
+            await event.wait()
+            raise
+
+        return op.get_results()
+
+    return wait()


### PR DESCRIPTION
Instead of using a Future, implement wrap_async using a coroutine. This simplifies the implementation and should make it robust against never completing. It will now also properly wait for cancellation of the underlying operation instead of immediately canceling the Future while the underlying operation is still running.

The function is moved to a new runtime._internals module to make it clear that it is not part of the public API. There isn't really a need for it to be public now that it is implemented as a coroutine.

Now asyncio.create_task() and asyncio.ensure_future() will work as expected rather than wrapping the Future in another Future or Task.