### PR TITLE
fix helper doc for package name and winmd file seperator

### DIFF
--- a/PyWinRT/Program.cs
+++ b/PyWinRT/Program.cs
@@ -278,7 +278,7 @@ var parser = new CommandLineBuilder(rootCommand)
                     Console.WriteLine("Where <spec> is one or more of:");
                     Console.WriteLine();
                     Console.WriteLine(
-                        "  <package>:<path>    Python package name and path to winmd file or recursively scanned folder"
+                        "  <package>;<path>    Python package name and path to winmd file or recursively scanned folder"
                     );
                     Console.WriteLine(
                         "  local               Local %WinDir%\\System32\\WinMetadata folder"


### PR DESCRIPTION
While CLI help doc says package name and path is using ':' as separator, the actual implementation and existing scripts are using ';'. 

https://github.com/pywinrt/pywinrt/blob/eea5c431a10f18f8e13d38d4ecc3f5c168b5a5f3/PyWinRT/CommandReader.cs#L234